### PR TITLE
Add fix that allows initial migration to run

### DIFF
--- a/app/Console/Commands/FetchFacebookEvents.php
+++ b/app/Console/Commands/FetchFacebookEvents.php
@@ -3,6 +3,7 @@
 namespace ICT\Console\Commands;
 
 use Illuminate\Console\Command;
+use Schema;
 
 use ICT\Services\FacebookEventFetcher;
 use ICT\Venue;
@@ -47,9 +48,12 @@ class FetchFacebookEvents extends Command
      */
     public function __construct(facebookEventFetcher $fetcher)
     {
+
         parent::__construct();
 
         $this->fetcher = $fetcher;
+
+        if (!Schema::hasTable('venues')) return;
 
         $this->venues = Venue::whereNotNull('facebook')->get();
         $this->organizations = Organization::whereNotNull('facebook')->get();


### PR DESCRIPTION
The `FetchFacebookEvents` service was running to fetch events, which depends on
the venues table being present. So, we check if it's not there and return. Next
time it will be there and will go through just fine.